### PR TITLE
Workaround for  tingodb

### DIFF
--- a/src/connect-mongo.js
+++ b/src/connect-mongo.js
@@ -85,7 +85,7 @@ export default function connectMongo(connect) {
                 } else {
                     options.mongooseConnection.once('open', () => this.handleNewConnectionAsync(options.mongooseConnection.db));
                 }
-            } else if (options.db && options.db.listCollections) {
+            } else if (options.db && (options.db.listCollections || options.db._path)) {
                 // Re-use existing or upcoming native connection
                 debug('use strategy: `native_db`');
                 if (options.db.openCalled || options.db.openCalled === undefined) { // openCalled is undefined in mongodb@2.x


### PR DESCRIPTION
Check if _path exists to enable usage of tingodb
